### PR TITLE
Add ArchLinux Package installation method to Documentation

### DIFF
--- a/Documentation/pages/GettingStarted.html
+++ b/Documentation/pages/GettingStarted.html
@@ -104,6 +104,15 @@
                 </li>
             </ul>
             <h3>
+                Installing the Arch Linux Package
+            </h3>
+            <p>
+              There is a <a href="https://aur.archlinux.org/packages/visibletesla/">visibletesla</a> package available for Arch Linux, you can install it by an AUR helper, such as yaourt
+            </p>
+            <p>
+              $ yaourt -S visibletesla
+            </p>
+            <h3>
                 Updating VisibleTesla
             </h3>
             <p>


### PR DESCRIPTION
I've create a Arch Linux package, https://aur.archlinux.org/packages/visibletesla/

USAGE

```
$ yaourt -S visibletesla
```
